### PR TITLE
Allow specifying parquet file outputs

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -195,3 +195,15 @@ def test_builder_invalid_save_kwargs(tmp_path):
             aggregations=[],
             groupby_attrs=[],
         )
+    with pytest.warns(DeprecationWarning, match='to_csv_kwargs is deprecated'):
+        builder.save(
+            name='test',
+            path_column_name='path',
+            directory=str(tmp_path),
+            data_format='netcdf',
+            variable_column_name='variables',
+            file_format='parquet',
+            to_csv_kwargs={'index': False},
+            aggregations=[],
+            groupby_attrs=[],
+        )


### PR DESCRIPTION
## Change Summary

- Allow `Builder` to write out a parquet file catalog

## Related issue number

N/A

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [x] Documentation reflects the changes where applicable
